### PR TITLE
Fix for #3: Support tests being split across multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 Run tests with standard TAP tools like prove:
 
-    $ prove -v -e 'swipl -q -t main -f' t/example.pl
+    $ prove -v -e 'swipl -q -t main -s' t/example.pl
     TAP version 13
     1..3
     ok 1 - two plus two is four

--- a/prolog/tap.pl
+++ b/prolog/tap.pl
@@ -33,7 +33,7 @@ term_wants_tap_expansion :-
 user:term_expansion(end_of_file, _) :-
     % build main/0
     term_wants_tap_expansion,
-    prolog_load_context(script,true),
+    prolog_load_context(script, true),
     findall(tap_call(Head), tap:test_case(Head), Tests0),
     length(Tests0, TestCount),
     tap_state(State),

--- a/prolog/tap.pl
+++ b/prolog/tap.pl
@@ -33,6 +33,7 @@ term_wants_tap_expansion :-
 user:term_expansion(end_of_file, _) :-
     % build main/0
     term_wants_tap_expansion,
+    prolog_load_context(script,true),
     findall(tap_call(Head), tap:test_case(Head), Tests0),
     length(Tests0, TestCount),
     tap_state(State),


### PR DESCRIPTION
Calling the Prolog file using the `-s` flag instead of `-f` allows to check for [`prolog_load_context(script, true)`](http://www.swi-prolog.org/pldoc/doc_for?object=predicate_property/2) in the `end_of_file` term expansion. This way the `main/0` is created only once for the directly called test definition file. So it will catch all tests defined in previously consulted files, too.

This is a fix for issue #3. Please not that this is a breaking, i.e. `MAJOR` change according to [semver](http://semver.org/).